### PR TITLE
plus de support de citation et math pour signature

### DIFF
--- a/markdown/extensions/zds.py
+++ b/markdown/extensions/zds.py
@@ -58,10 +58,10 @@ class ZdsExtension(Extension):
         del_ext         = DelExtension()            # Del support
         urlize_ext      = UrlizeExtension()         # Autolink support
         kbd_ext         = KbdExtension()            # Keyboard support
-        mathjax_ext     = MathJaxExtension()        # MathJax support
         emo_ext         = EmoticonExtension({"EMOTICONS" : self.emoticons}) # smileys support
-        sm_ext          = SmartyExtension((('smart_quotes', False),))
         if not self.inline:
+            sm_ext          = SmartyExtension((('smart_quotes', False),))
+            mathjax_ext     = MathJaxExtension()        # MathJax support
             customblock_ext = CustomBlockExtension(
                 { "s(ecret)?"       : "spoiler",
                   "i(nformation)?"  : "information ico-after",


### PR DESCRIPTION
Enlève le support des citations et de mathjax dans les signature.

Voir zestedesavoir/zds-site#1000
