### PR TITLE
Add support of table of content

### DIFF
--- a/markdown/extensions/zds.py
+++ b/markdown/extensions/zds.py
@@ -45,6 +45,7 @@ from .smartLegend import SmartLegendExtension
 from .headerDec import DownHeaderExtension
 from .smarty import SmartyExtension
 from .codehilite import CodeHiliteExtension
+from .toc import TocExtension
 
 
 class ZdsExtension(Extension):
@@ -94,6 +95,7 @@ class ZdsExtension(Extension):
             legend_ext = SmartLegendExtension({"IGNORING_IMG": self.emoticons.values(),
                                                "PARENTS": ("div", "blockquote")})  # Smart Legend support
             dheader_ext = DownHeaderExtension({"OFFSET": 2})  # Offset header support
+            toc_ext         = TocExtension(baselevel=3, anchorlink=True, marker="[sommaire]")
         # Define used ext
         exts = [sub_ext,  # Subscript support
                 del_ext,  # Del support
@@ -101,6 +103,7 @@ class ZdsExtension(Extension):
                 sm_ext,
                 ]
         if not self.inline:
+<<<<<<< 97965b090d9da07523c903296b308815168f2e72
             exts.extend(['markdown.extensions.abbr',  # Abbreviation support, included in python-markdown
                          'markdown.extensions.footnotes',  # Footnotes support, included in python-markdown
                          # Footnotes place marker can be set with the PLACE_MARKER option
@@ -121,6 +124,29 @@ class ZdsExtension(Extension):
                          dheader_ext,  # Down Header support
                          mathjax_ext,  # Mathjax support
                          ])
+=======
+            exts.extend([
+                'markdown.extensions.abbr',                             # Abbreviation support, included in python-markdown
+                'markdown.extensions.footnotes',                        # Footnotes support, included in python-markdown
+                                                    # Footnotes place marker can be set with the PLACE_MARKER option
+                'markdown.extensions.tables',                           # Tables support, included in python-markdown
+                'markdown.extensions.fenced_code',                      # Extended syntaxe for code block support, included in python-markdown
+                CodeHiliteExtension(linenums=True,guess_lang=False),
+                                                    # Code hightlight support, with line numbers, included in python-markdwon
+                customblock_ext,                    # CustomBlock support
+                kbd_ext,                            # Kbd support
+                emo_ext,                            # Smileys support
+                video_ext,                          # Video support
+                preprocess_ext,                     # Preprocess support
+                gridtable_ext,                      # Grid tables support
+                comment_ext,                        # Comment support
+                legend_ext,                         # Legend support
+                align_ext,                          # Right align and center support
+                dheader_ext,                        # Down Header support
+                mathjax_ext,                        # Mathjax support
+                toc_ext,                            # Table of content support
+                ])
+>>>>>>> add support of table of content
         md.registerExtensions(exts, {})
         if self.inline:
             # md.parser.blockprocessors.clear()

--- a/markdown/extensions/zds.py
+++ b/markdown/extensions/zds.py
@@ -95,7 +95,7 @@ class ZdsExtension(Extension):
             legend_ext = SmartLegendExtension({"IGNORING_IMG": self.emoticons.values(),
                                                "PARENTS": ("div", "blockquote")})  # Smart Legend support
             dheader_ext = DownHeaderExtension({"OFFSET": 2})  # Offset header support
-            toc_ext = TocExtension(baselevel=3, anchorlink=True, marker="")
+            toc_ext = TocExtension(baselevel=1, anchorlink=True, marker="")
         # Define used ext
         exts = [sub_ext,  # Subscript support
                 del_ext,  # Del support

--- a/markdown/extensions/zds.py
+++ b/markdown/extensions/zds.py
@@ -95,7 +95,7 @@ class ZdsExtension(Extension):
             legend_ext = SmartLegendExtension({"IGNORING_IMG": self.emoticons.values(),
                                                "PARENTS": ("div", "blockquote")})  # Smart Legend support
             dheader_ext = DownHeaderExtension({"OFFSET": 2})  # Offset header support
-            toc_ext         = TocExtension(baselevel=3, anchorlink=True, marker="")
+            toc_ext = TocExtension(baselevel=3, anchorlink=True, marker="")
         # Define used ext
         exts = [sub_ext,  # Subscript support
                 del_ext,  # Del support

--- a/markdown/extensions/zds.py
+++ b/markdown/extensions/zds.py
@@ -122,6 +122,7 @@ class ZdsExtension(Extension):
                          align_ext,  # Right align and center support
                          dheader_ext,  # Down Header support
                          mathjax_ext,  # Mathjax support
+                         toc_ext,  # Anchor link
                          ])
         md.registerExtensions(exts, {})
         if self.inline:

--- a/markdown/extensions/zds.py
+++ b/markdown/extensions/zds.py
@@ -95,7 +95,7 @@ class ZdsExtension(Extension):
             legend_ext = SmartLegendExtension({"IGNORING_IMG": self.emoticons.values(),
                                                "PARENTS": ("div", "blockquote")})  # Smart Legend support
             dheader_ext = DownHeaderExtension({"OFFSET": 2})  # Offset header support
-            toc_ext         = TocExtension(baselevel=3, anchorlink=True, marker="[sommaire]")
+            toc_ext         = TocExtension(baselevel=3, anchorlink=True, marker="")
         # Define used ext
         exts = [sub_ext,  # Subscript support
                 del_ext,  # Del support
@@ -103,7 +103,6 @@ class ZdsExtension(Extension):
                 sm_ext,
                 ]
         if not self.inline:
-<<<<<<< 97965b090d9da07523c903296b308815168f2e72
             exts.extend(['markdown.extensions.abbr',  # Abbreviation support, included in python-markdown
                          'markdown.extensions.footnotes',  # Footnotes support, included in python-markdown
                          # Footnotes place marker can be set with the PLACE_MARKER option
@@ -124,29 +123,6 @@ class ZdsExtension(Extension):
                          dheader_ext,  # Down Header support
                          mathjax_ext,  # Mathjax support
                          ])
-=======
-            exts.extend([
-                'markdown.extensions.abbr',                             # Abbreviation support, included in python-markdown
-                'markdown.extensions.footnotes',                        # Footnotes support, included in python-markdown
-                                                    # Footnotes place marker can be set with the PLACE_MARKER option
-                'markdown.extensions.tables',                           # Tables support, included in python-markdown
-                'markdown.extensions.fenced_code',                      # Extended syntaxe for code block support, included in python-markdown
-                CodeHiliteExtension(linenums=True,guess_lang=False),
-                                                    # Code hightlight support, with line numbers, included in python-markdwon
-                customblock_ext,                    # CustomBlock support
-                kbd_ext,                            # Kbd support
-                emo_ext,                            # Smileys support
-                video_ext,                          # Video support
-                preprocess_ext,                     # Preprocess support
-                gridtable_ext,                      # Grid tables support
-                comment_ext,                        # Comment support
-                legend_ext,                         # Legend support
-                align_ext,                          # Right align and center support
-                dheader_ext,                        # Down Header support
-                mathjax_ext,                        # Mathjax support
-                toc_ext,                            # Table of content support
-                ])
->>>>>>> add support of table of content
         md.registerExtensions(exts, {})
         if self.inline:
             # md.parser.blockprocessors.clear()

--- a/tests/zds/rediger_sur_zds_part1.html
+++ b/tests/zds/rediger_sur_zds_part1.html
@@ -1,4 +1,4 @@
-<h3>Paragraphes</h3>
+<h3 id="paragraphes"><a class="toclink" href="#paragraphes">Paragraphes</a></h3>
 <p>Les paragraphes s'écrivent naturellement, en sautant une ligne :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
@@ -22,7 +22,7 @@ Ceci est mon second paragraphe.
 <p>Si vraiment vous tenez à revenir à la ligne sans changer de paragraphe, comme ceci<br>
 par exemple, alors il suffit de terminer la première ligne par deux espaces.</p>
 <p>De plus, le Markdown standard autorise l'insertion de HTML, mais pour des raisons de sécurité nous avons choisi de ne pas laisser cette possibilité. Si vous écrivez du HTML, celui-ci apparaitra donc tel quel dans votre texte.</p>
-<h3>Titres</h3>
+<h3 id="titres"><a class="toclink" href="#titres">Titres</a></h3>
 <p>Les titres sont précédés d'un ou plusieurs croisillons suivant le niveau hiérarchique voulu. Ainsi un titre de premier niveau s'écrit avec un seul croisillon, un titre de deuxième niveau avec deux croisillons, etc.</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
@@ -41,7 +41,7 @@ par exemple, alors il suffit de terminer la première ligne par deux espaces.</p
 </td></tr></table>
 
 <p>Quatre niveaux hiérarchiques sont possibles. J'attire d'ailleurs votre attention sur ce point car il est très important de donner la bonne hiérarchie à vos titres lorsque vous rédigerez vos tutoriels.</p>
-<h3>Emphases</h3>
+<h3 id="emphases"><a class="toclink" href="#emphases">Emphases</a></h3>
 <p>Les emphases permettent de mettre un morceau de votre texte en valeur. Deux types d'emphases sont disponibles : l'italique et le gras.</p>
 <p>Pour mettre du texte en <em>italique</em>, utilisez l'astérisque ou le souligné (<em>underscore</em>) :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Le mot *italique* est en italique.
@@ -67,14 +67,14 @@ par exemple, alors il suffit de terminer la première ligne par deux espaces.</p
 </td></tr></table>
 
 <p>Par souci de simplicité et de lisibilité, vous ne pourrez pas mettre du texte en couleur, le souligner, changer sa taille ou bien encore en changer la police.</p>
-<h3>Barrer</h3>
+<h3 id="barrer"><a class="toclink" href="#barrer">Barrer</a></h3>
 <p>Barrer du texte (<del>comme ceci</del>) se fait en utilisant deux tildes successifs avant et après la portion de texte concernée :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Le mot ~~barré~~ est barré.
 </pre></div>
 </td></tr></table>
 
 <p>Pour information, il s'agit de la syntaxe utilisée par Pandoc.</p>
-<h3>Alignement du texte</h3>
+<h3 id="alignement-du-texte"><a class="toclink" href="#alignement-du-texte">Alignement du texte</a></h3>
 <p>Par défaut, le texte est bien évidemment aligné à gauche. Comme nous le verrons plus loin, certains éléments sont centrés automatiquement, comme les images seules dans leur paragraphe par exemple. Vous n'avez donc en général pas à vous soucier de l'alignement du texte : le site s'en charge pour vous.</p>
 <p>Dans les rares cas où vous souhaiteriez centrer volontairement un texte (si l'envie vous prenait d'écrire un poème par exemple), vous pourriez néanmoins utiliser la syntaxe ci-dessous :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>-&gt; Ce texte est centré. &lt;- 
@@ -89,7 +89,7 @@ par exemple, alors il suffit de terminer la première ligne par deux espaces.</p
 <p>Il est impossible d'imbriquer des alignements. Cela n'aurait de toute façon pas de sens (comment aligner à droite un texte centré ?).</p>
 <p>Encore une fois, l'alignement est géré automatiquement dans la majorité des cas. N'en abusez pas, cela pourrait gêner la lecture.</p>
 <p>Enfin, sachez qu'il est impossible de justifier du texte sur le site.</p>
-<h3>Indices et exposants</h3>
+<h3 id="indices-et-exposants"><a class="toclink" href="#indices-et-exposants">Indices et exposants</a></h3>
 <p>Là encore, ce sont les syntaxes de Pandoc qui sont utilisées pour mettre en indice ou en exposant une portion de texte.</p>
 <p>On utilise l'accent circonflexe pour l'exposant. Si par exemple on veut écrire que 2<sup>10</sup> vaut 1024, alors on écrira :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>2^10^ vaut 1024.

--- a/tests/zds/rediger_sur_zds_part3.html
+++ b/tests/zds/rediger_sur_zds_part3.html
@@ -1,5 +1,5 @@
 <p>Il existe deux façons d'écrire des liens : avec ou sans texte d'ancrage.</p>
-<h3>Liens et emails avec texte d'ancrage</h3>
+<h3 id="liens-et-emails-avec-texte-dancrage"><a class="toclink" href="#liens-et-emails-avec-texte-dancrage">Liens et emails avec texte d'ancrage</a></h3>
 <p>Pour faire un <a href="http://www.zestedesavoir.com" title="Zeste de Savoir">lien</a> sur un morceau de texte (qu'on appelle donc texte d'ancrage, ici le mot "lien"), on utilise la syntaxe suivante :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Pour faire un [lien](http://www.zestedesavoir.com &quot;Zeste de Savoir&quot;) sur un morceau de texte
 </pre></div>
@@ -12,6 +12,6 @@
 </pre></div>
 </td></tr></table>
 
-<h3>Liens présentés sous forme d'URL ou d'email</h3>
+<h3 id="liens-presentes-sous-forme-durl-ou-demail"><a class="toclink" href="#liens-presentes-sous-forme-durl-ou-demail">Liens présentés sous forme d'URL ou d'email</a></h3>
 <p>Si vous ne souhaitez pas utiliser de texte d'ancrage et ainsi rendre une URL ou un email cliquable, alors vous n'avez rien à faire : URL et emails seront automatiquement cliquables.</p>
 <p>Pour les emails, vous n'avez donc même pas besoin de vous soucier du "mailto".</p>

--- a/tests/zds/rediger_sur_zds_part4.html
+++ b/tests/zds/rediger_sur_zds_part4.html
@@ -1,4 +1,4 @@
-<h3>Des tableaux simples</h3>
+<h3 id="des-tableaux-simples"><a class="toclink" href="#des-tableaux-simples">Des tableaux simples</a></h3>
 <p>Pour faire un tableau, la façon la plus simple est encore de le dessiner, à l'aide de barres verticales et de tirets :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
@@ -44,7 +44,7 @@ Mathilde  | 35
 </table>
 </div>
 <p>Cette syntaxe est simple mais elle a ses limites : il est impossible de revenir à la ligne dans une cellule ou bien de fusionner des lignes ou des colonnes. Si vous avez vraiment besoin de faire cela, il vous faudra utiliser une autre syntaxe de tableau, plus lourde mais plus complète, comme nous allons le voir à présent.</p>
-<h3>Tableaux complexes</h3>
+<h3 id="tableaux-complexes"><a class="toclink" href="#tableaux-complexes">Tableaux complexes</a></h3>
 <p>Pour des tableaux plus complexes, dans lesquels vous pourrez notamment revenir à la ligne dans une cellule et fusionner des lignes ou colonnes, il vous faut utiliser la syntaxe dite « grid-table » :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre> 1
  2
@@ -137,10 +137,10 @@ too</p>
 </tbody>
 </table>
 </div>
-<h3>Légendes de tableaux</h3>
+<h3 id="legendes-de-tableaux"><a class="toclink" href="#legendes-de-tableaux">Légendes de tableaux</a></h3>
 <p>Quelle que soit la syntaxe utilisée, vous pouvez indiquer une légende à votre tableau en ajoutant une ligne <code>Table: Ma légende</code> juste en dessous du tableau.</p>
 <p>Le mot « Table » est optionnel, pas les deux-points. Il peut y avoir un espace entre « Table » et les deux-points.</p>
-<h3>Lignes horizontales</h3>
+<h3 id="lignes-horizontales"><a class="toclink" href="#lignes-horizontales">Lignes horizontales</a></h3>
 <p>Pour tracer une ligne horizontale, le principe est le même : <em>dessinez-là</em>. La syntaxe est cette fois bien plus simple puisqu'elle n'est constituée que de trois tirets (ou plus, ça ne change rien au résultat) :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>------
 </pre></div>

--- a/tests/zds/rediger_sur_zds_part6.html
+++ b/tests/zds/rediger_sur_zds_part6.html
@@ -1,4 +1,4 @@
-<h3>Bloc de code</h3>
+<h3 id="bloc-de-code"><a class="toclink" href="#bloc-de-code">Bloc de code</a></h3>
 <p>Il n'est pas rare d'illustrer son propos d'un petit exemple de code :</p>
 <figure><table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
@@ -57,7 +57,7 @@ print(&quot;Hello, World!&quot;)
 </td></tr></table>
 
 <p>Là encore, vous pouvez mettre une légende à votre bloc de code en ajoutant, juste en dessous du bloc, une ligne <code>Code:Votre légende</code>.</p>
-<h3>Mise en évidence de lignes de code</h3>
+<h3 id="mise-en-evidence-de-lignes-de-code"><a class="toclink" href="#mise-en-evidence-de-lignes-de-code">Mise en évidence de lignes de code</a></h3>
 <p>Mettre en évidence une portion de code permet d'appuyer votre explication :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
@@ -96,7 +96,7 @@ print &quot;Bonjour, $nom !\n&quot;;
 </pre></div>
 </td></tr></table>
 
-<h3>Début de la numérotation</h3>
+<h3 id="debut-de-la-numerotation"><a class="toclink" href="#debut-de-la-numerotation">Début de la numérotation</a></h3>
 <p>Il est possible de spécifier le début de numération. Par exemple :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>10
 11
@@ -109,7 +109,7 @@ print &quot;Bonjour, $nom !\n&quot;;
 </td></tr></table>
 
 <p>On utilise le mot-clé <code>linenostart</code> de la même façon que le <code>hl_lines</code> vu précédemment.</p>
-<h3>Code inline</h3>
+<h3 id="code-inline"><a class="toclink" href="#code-inline">Code inline</a></h3>
 <p>Enfin, si vous souhaitez insérer un petit élément de code dans votre phrase (comme <code>print</code> par exemple), alors un seul accent grave autour du mot suffira :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>comme `print` par exemple
 </pre></div>

--- a/tests/zds/rediger_sur_zds_part7.html
+++ b/tests/zds/rediger_sur_zds_part7.html
@@ -1,4 +1,4 @@
-<h3>Images</h3>
+<h3 id="images"><a class="toclink" href="#images">Images</a></h3>
 <p>L'insertion d'une image ressemble à celle d'un lien, à ceci près que le texte d'ancrage doit être remplacé par un texte alternatif :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>![Logo Creative Commons](http://mirrors.creativecommons.org/presskit/logos/cc.logo.png)
 </pre></div>
@@ -48,7 +48,7 @@ Bla bla bla
 </td></tr></table>
 
 <p>Ainsi, le texte alternatif et la légende sont bien différents.</p>
-<h3>Vidéos</h3>
+<h3 id="videos"><a class="toclink" href="#videos">Vidéos</a></h3>
 <p>Les vidéos doivent être insérées avec une syntaxe dédié : <code>!(URL Vidéo)</code>. Elles ne peuvent être inline (au sein d'une phrase). </p>
 <p>Pour insérer une vidéo on peut donc faire :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
@@ -80,14 +80,14 @@ Bla bla bla
 
 <p>Par exemple :</p>
 <figure><iframe allowfullscreen="true" frameborder="0" height="315" src="https://www.youtube.com/embed/oavMtUWDBTM" width="560"></iframe>
-<figcaption><p>Ma super légende</p></figcaption></figure><h3>Touches</h3>
+<figcaption><p>Ma super légende</p></figcaption></figure><h3 id="touches"><a class="toclink" href="#touches">Touches</a></h3>
 <p>Pour représenter une touche, utilisez deux barres verticales avant et après le nom de la touche :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Utilisez ||Ctrl|| + ||C|| pour copier.
 </pre></div>
 </td></tr></table>
 
 <p>Vous pouvez bien sûr mettre <kbd>ce que vous voulez</kbd> comme nom de touche.</p>
-<h3>Smileys</h3>
+<h3 id="smileys"><a class="toclink" href="#smileys">Smileys</a></h3>
 <p>Que serait un forum sans smileys ? Un forum plus agréable ? Peut-être. Il n'empêche que les fameux smileys sont incontournables. Sur ZdS, les smileys que vous écrivez seront automatiquement transformés en image. Ci-dessous une liste (non exhaustive) des smileys disponibles :</p>
 <div class="table-wrapper">
 <table>

--- a/tests/zds/rediger_sur_zds_part8.html
+++ b/tests/zds/rediger_sur_zds_part8.html
@@ -1,4 +1,4 @@
-<h3>Balises attention, erreur, information, question et secret</h3>
+<h3 id="balises-attention-erreur-information-question-et-secret"><a class="toclink" href="#balises-attention-erreur-information-question-et-secret">Balises attention, erreur, information, question et secret</a></h3>
 <p>Les tutoriels et articles de ZdS sont parsemés de balises telles que la balise "information" :</p>
 <div class="information ico-after">
 <p>Ceci est une balise d'information.</p>
@@ -35,7 +35,7 @@
 <li>secret</li>
 </ul>
 <p>La balise "secret" (appelée "spoiler" sur certains sites) a ceci de spécial qu'elle masque son contenu par défaut et ne le rend visible qu'au clic de l'utilisateur.</p>
-<h3>Citations</h3>
+<h3 id="citations"><a class="toclink" href="#citations">Citations</a></h3>
 <p>Les citations permettent de séparer votre propos de celui que vous rapportez. D'ailleurs, si l'on en croit ce vieux proverbe nous venant d'une petite planète quelque part aux confins de Bételgeuse, il ne faut pas s'en priver :</p>
 <figure><blockquote>
 <p>Les citations, c'est bien.

--- a/tests/zds/rediger_sur_zds_part9.html
+++ b/tests/zds/rediger_sur_zds_part9.html
@@ -1,4 +1,4 @@
-<h3>Abréviations</h3>
+<h3 id="abreviations"><a class="toclink" href="#abreviations">Abréviations</a></h3>
 <p>Il est souvent utile de préciser la signification d'une abréviation (notamment d'un acronyme ou d'un sigle), sans toutefois la faire figurer dans le corps du texte. En utilisant la syntaxe suivante, la signification apparaîtra au passage de la souris sur l'abréviation :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
@@ -9,7 +9,7 @@
 </td></tr></table>
 
 <p>Bienvenue, donc, sur <abbr title="Zeste de Savoir">ZdS</abbr> !</p>
-<h3>Notes de bas de page</h3>
+<h3 id="notes-de-bas-de-page"><a class="toclink" href="#notes-de-bas-de-page">Notes de bas de page</a></h3>
 <p>Toujours dans l'idée d'enrichir votre texte<sup id="fnref-enrich"><a class="footnote-ref" href="#fn-enrich">1</a></sup>, vous pouvez utiliser des notes de base de page :</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2


### PR DESCRIPTION
Le but de cette PR est de permettre aux titres dans le contenu du markdown d'être _linkable_. 

La PR ajoute aussi la syntaxe `[sommaire]` pour permettre aux auteurs de générer un sommaire automatiquement.
