### PR TITLE
Specific zds-extensions tests : align

### DIFF
--- a/markdown/extensions/align.py
+++ b/markdown/extensions/align.py
@@ -11,8 +11,8 @@ class AlignProcessor(BlockProcessor):
 
     def __init__(self, parser):
         BlockProcessor.__init__(self, parser)
-        
-        exprs = (( "->", "right"), ("<-", "center"))
+
+        exprs = (("->", "right"), ("<-", "center"))
 
         self.REStart = re.compile(r'(^|\n)' + re.escape('->'))
         self._ending_re = [re.compile(re.escape(end_expr) + r'(\n|$)') for end_expr, _ in exprs]
@@ -100,6 +100,7 @@ class AlignExtension(markdown.extensions.Extension):
         """Modifies inline patterns."""
         md.registerExtension(self)
         md.parser.blockprocessors.add('align', AlignProcessor(md.parser), '_begin')
+
 
 def makeExtension(*args, **kwargs):
     return AlignExtension(*args, **kwargs)

--- a/markdown/extensions/align.py
+++ b/markdown/extensions/align.py
@@ -25,7 +25,7 @@ class AlignProcessor(BlockProcessor):
 
         FirstBlock = blocks[0]
         m = self.REStart.search(FirstBlock)
-        if not m: # pragma: no cover
+        if not m:  # pragma: no cover
             # Run should only be fired if test() return True, then this should never append
             # Do not raise an exception because exception should never be generated.
             return False
@@ -54,9 +54,9 @@ class AlignProcessor(BlockProcessor):
         if EndBlock[0] < 0:
             # Block not ended, do not transform
             return False
-        
+
         # Split blocks into before/content aligned/ending
-        # There should never have before and ending because regex require that the expression is starting/ending the 
+        # There should never have before and ending because regex require that the expression is starting/ending the
         # block. This is set for security : if regex are updated the code should always work.
         Before = FirstBlock[:StartBlock[1]]
         Content = []
@@ -78,7 +78,7 @@ class AlignProcessor(BlockProcessor):
 
         Content = "\n\n".join(Content)
 
-        if Before: # pragma: no cover
+        if Before:  # pragma: no cover
             # This should never occur because regex require that the expression is starting the block.
             # Do not raise an exception because exception should never be generated.
             self.parser.parseBlocks(parent, [Before])
@@ -98,7 +98,7 @@ class AlignProcessor(BlockProcessor):
 
         self.parser.parseChunk(h, Content)
 
-        if After: # pragma: no cover
+        if After:  # pragma: no cover
             # This should never occur because regex require that the expression is ending the block.
             # Do not raise an exception because exception should never be generated.
             blocks.insert(0, After)

--- a/markdown/extensions/align.py
+++ b/markdown/extensions/align.py
@@ -9,12 +9,14 @@ from markdown import util
 class AlignProcessor(BlockProcessor):
     """ Process Align. """
 
-    def __init__(self, parser, startExpr, endExpr, contentAlign):
+    def __init__(self, parser):
         BlockProcessor.__init__(self, parser)
+        
+        exprs = (( "->", "right"), ("<-", "center"))
 
-        self.REStart = re.compile(r'(^|\n)' + re.escape(startExpr))
-        self.REEnd = re.compile(re.escape(endExpr) + r'(\n|$)')
-        self.contentAlign = contentAlign
+        self.REStart = re.compile(r'(^|\n)' + re.escape('->'))
+        self._ending_re = [re.compile(re.escape(end_expr) + r'(\n|$)') for end_expr, _ in exprs]
+        self._kind_align = [kind_align for _, kind_align in exprs]
 
     def test(self, parent, block):
         return bool(self.REStart.search(block))
@@ -28,6 +30,7 @@ class AlignProcessor(BlockProcessor):
         StartBlock = (0, m.start(), m.end())
 
         EndBlock = (-1, -1, -1)
+        content_align = "left"
         for i in range(len(blocks)):
             if i == 0:
                 txt = FirstBlock[m.end() + 1:]
@@ -35,10 +38,15 @@ class AlignProcessor(BlockProcessor):
             else:
                 txt = blocks[i]
                 dec = 0
-
-            mEnd = self.REEnd.search(txt)
-            if mEnd:
+            # Test all ending aligns
+            t_ends = ((i, re_end.search(txt)) for i, re_end in enumerate(self._ending_re))
+            # Catch only matching re
+            t_ends = list(filter(lambda e: e[1] is not None, t_ends))
+            if len(t_ends) > 0:
+                # retrieve first matching re
+                selected_align, mEnd = min(t_ends, key=lambda e: e[1].start())
                 EndBlock = (i, mEnd.start() + dec, mEnd.end() + dec)
+                content_align = self._kind_align[selected_align]
                 break
 
         if EndBlock[0] < 0:
@@ -70,14 +78,14 @@ class AlignProcessor(BlockProcessor):
         if (sibling and
                 sibling.tag == "div" and
                 "align" in sibling.attrib and
-                sibling.attrib["align"] == self.contentAlign):
+                sibling.attrib["align"] == content_align):
             h = sibling
 
             if h.text:
                 h.text += '\n'
         else:
             h = util.etree.SubElement(parent, 'div')
-            h.set("align", self.contentAlign)
+            h.set("align", content_align)
 
         self.parser.parseChunk(h, Content)
 
@@ -91,9 +99,7 @@ class AlignExtension(markdown.extensions.Extension):
     def extendMarkdown(self, md, md_globals):
         """Modifies inline patterns."""
         md.registerExtension(self)
-        md.parser.blockprocessors.add('rightalign', AlignProcessor(md.parser, "->", "->", "right"), '_begin')
-        md.parser.blockprocessors.add('centeralign', AlignProcessor(md.parser, "->", "<-", "center"), '_begin')
+        md.parser.blockprocessors.add('align', AlignProcessor(md.parser), '_begin')
 
-
-def makeExtension(configs={}):
-    return AlignExtension(configs=dict(configs))
+def makeExtension(*args, **kwargs):
+    return AlignExtension(*args, **kwargs)

--- a/markdown/extensions/align.py
+++ b/markdown/extensions/align.py
@@ -25,7 +25,9 @@ class AlignProcessor(BlockProcessor):
 
         FirstBlock = blocks[0]
         m = self.REStart.search(FirstBlock)
-        if not m:
+        if not m: # pragma: no cover
+            # Run should only be fired if test() return True, then this should never append
+            # Do not raise an exception because exception should never be generated.
             return False
         StartBlock = (0, m.start(), m.end())
 
@@ -50,7 +52,12 @@ class AlignProcessor(BlockProcessor):
                 break
 
         if EndBlock[0] < 0:
+            # Block not ended, do not transform
             return False
+        
+        # Split blocks into before/content aligned/ending
+        # There should never have before and ending because regex require that the expression is starting/ending the 
+        # block. This is set for security : if regex are updated the code should always work.
         Before = FirstBlock[:StartBlock[1]]
         Content = []
         After = blocks[EndBlock[0]][EndBlock[2]:]
@@ -71,7 +78,9 @@ class AlignProcessor(BlockProcessor):
 
         Content = "\n\n".join(Content)
 
-        if Before:
+        if Before: # pragma: no cover
+            # This should never occur because regex require that the expression is starting the block.
+            # Do not raise an exception because exception should never be generated.
             self.parser.parseBlocks(parent, [Before])
 
         sibling = self.lastChild(parent)
@@ -79,8 +88,8 @@ class AlignProcessor(BlockProcessor):
                 sibling.tag == "div" and
                 "align" in sibling.attrib and
                 sibling.attrib["align"] == content_align):
+            # If previous block is the same align content, merge it !
             h = sibling
-
             if h.text:
                 h.text += '\n'
         else:
@@ -89,7 +98,9 @@ class AlignProcessor(BlockProcessor):
 
         self.parser.parseChunk(h, Content)
 
-        if After:
+        if After: # pragma: no cover
+            # This should never occur because regex require that the expression is ending the block.
+            # Do not raise an exception because exception should never be generated.
             blocks.insert(0, After)
 
 

--- a/markdown/extensions/align.py
+++ b/markdown/extensions/align.py
@@ -90,7 +90,9 @@ class AlignProcessor(BlockProcessor):
                 sibling.attrib["align"] == content_align):
             # If previous block is the same align content, merge it !
             h = sibling
-            if h.text:
+            if h.text:  # pragma: no cover
+                # This should never occur because there should never have content text outside of blocks html elements.
+                # this code come from other markdown processors, maybe this can happen because of this shitty ast.
                 h.text += '\n'
         else:
             h = util.etree.SubElement(parent, 'div')

--- a/tests/zds/extensions/align.html
+++ b/tests/zds/extensions/align.html
@@ -1,0 +1,29 @@
+<h1>Test align</h1>
+<p>A simple paragraph</p>
+<div align="center">
+<p>A centered paragraph</p>
+</div>
+<p>a simple paragraph</p>
+<div align="right">
+<p>A right aligned paragraph</p>
+</div>
+<p>an other simple paragraph</p>
+<p>A simple paragraph</p>
+<div align="center">
+<p>A centered paragraph</p>
+</div>
+<p>a simple paragraph</p>
+<div align="right">
+<p>A right aligned paragraph</p>
+</div>
+<p>an other simple paragraph</p>
+<div align="center">
+<p>A centered paragraph.</p>
+<p>Containing two paragraph</p>
+</div>
+<p>an other simple paragraph</p>
+<div align="center">
+<p>A right aligned paragraph.</p>
+<p>Containing two paragraph</p>
+</div>
+<p>a simple paragraph</p>

--- a/tests/zds/extensions/align.html
+++ b/tests/zds/extensions/align.html
@@ -26,4 +26,10 @@
 <p>A right aligned paragraph.</p>
 <p>Containing two paragraph</p>
 </div>
+<p>an other simple paragraph</p>
+<div align="center">
+<p>A centered paragraph.</p>
+<p>An other centered paragraph.</p>
+</div>
 <p>a simple paragraph</p>
+<p>-&gt;A started block without end.</p>

--- a/tests/zds/extensions/align.txt
+++ b/tests/zds/extensions/align.txt
@@ -31,4 +31,11 @@ an other simple paragraph
 
 Containing two paragraph<-
 
+an other simple paragraph
+
+->A centered paragraph.<-
+->An other centered paragraph.<-
+
 a simple paragraph
+
+->A started block without end.

--- a/tests/zds/extensions/align.txt
+++ b/tests/zds/extensions/align.txt
@@ -1,0 +1,34 @@
+Test align
+==========
+
+A simple paragraph
+
+->A centered paragraph<-
+
+a simple paragraph
+
+->A right aligned paragraph->
+
+an other simple paragraph
+
+A simple paragraph
+
+->A centered paragraph<-
+
+a simple paragraph
+
+->A right aligned paragraph->
+
+an other simple paragraph
+
+->A centered paragraph.
+
+Containing two paragraph<-
+
+an other simple paragraph
+
+->A right aligned paragraph.
+
+Containing two paragraph<-
+
+a simple paragraph

--- a/tests/zds/extensions/test.cfg
+++ b/tests/zds/extensions/test.cfg
@@ -1,0 +1,6 @@
+DEFAULT:
+    output_format: html5
+
+align:
+    extensions:
+        - markdown.extensions.align


### PR DESCRIPTION
Rajoute des tests pour l'extension "align".

Un bug a été corrigé au passage, correspondant au #62 (ce qui explique les tests multiples d'une même expression, pour vérifier que le parseur s’arrête à la première expression de fin trouvée).

Extension qui mériterai probablement d'être simplifiée mais cela fonctionne et normalement sans bug.
