### PR TITLE
Correction de l’issue #52 sur les liens dans des liens.

### DIFF
--- a/markdown/inlinepatterns.py
+++ b/markdown/inlinepatterns.py
@@ -416,7 +416,7 @@ class LinkPattern(Pattern):
 
     def handleMatch(self, m):
         el = util.etree.Element("a")
-        el.text = m.group(2)
+        el.text = m.group(2).replace(".", "&#46;")
         title = m.group(13)
         href = m.group(9)
 


### PR DESCRIPTION
Juste un petit _hack_ pour régler l’issue #52 : dans le texte d’un lien, les points sont remplacés par l’entité HTML correspondante. Ainsi, ils restent affichés comme des points, mais ne sont plus reconnus par la regex en charge des liens « libres ».
