### PR TITLE
Nouvelle extension pour la typographie française.

### DIFF
--- a/markdown/extensions/french_typography.py
+++ b/markdown/extensions/french_typography.py
@@ -1,9 +1,10 @@
+# -*- coding: utf-8 -*-
 # Gestion fine de la typographie française, du moins, ce qui peut être
 # automatisé, Lointainement inspiré de l’extension SmartyPants.
 
-import re
 import markdown
 from ..inlinepatterns import HtmlPattern
+
 
 class ReplacePattern(HtmlPattern):
     def __init__(self, pattern, replacement, markdown):
@@ -14,6 +15,7 @@ class ReplacePattern(HtmlPattern):
 
     def handleMatch(self, m):
         return self.markdown.htmlStash.store(self.replacement, safe=True)
+
 
 class ReplaceWithSpacePattern(HtmlPattern):
     def __init__(self, pattern, replacement, markdown):
@@ -26,6 +28,7 @@ class ReplaceWithSpacePattern(HtmlPattern):
         space = m.group(2)
         replacement = self.replacement + space
         return self.markdown.htmlStash.store(replacement, safe=True)
+
 
 class FrenchTypographyExtension(markdown.extensions.Extension):
     def __init__(self, *args, **kwargs):
@@ -78,38 +81,38 @@ class FrenchTypographyExtension(markdown.extensions.Extension):
             'semicolon_with_space', semicolonWithSpacePattern, '_end'
         )
         self.replacements.add(
-            'colon_with_space', 
-            colonWithSpacePattern, 
+            'colon_with_space',
+            colonWithSpacePattern,
             '<semicolon_with_space'
         )
         self.replacements.add(
-            'interrogation_mark_with_space', 
-            interrogationWithSpacePattern, 
+            'interrogation_mark_with_space',
+            interrogationWithSpacePattern,
             '<colon_with_space'
         )
         self.replacements.add(
-            'exclamation_mark_with_space', 
-            exclamationWithSpacePattern, 
+            'exclamation_mark_with_space',
+            exclamationWithSpacePattern,
             '<interrogation_mark_with_space'
         )
         self.replacements.add(
-            'per_cent_with_space', 
-            perCentWithSpacePattern, 
+            'per_cent_with_space',
+            perCentWithSpacePattern,
             '<exclamation_mark_with_space'
         )
         self.replacements.add(
-            'per_mil_with_space', 
-            perMilWithSpacePattern, 
+            'per_mil_with_space',
+            perMilWithSpacePattern,
             '<per_cent_with_space'
         )
         self.replacements.add(
-            'opening_angle_quote_with_space', 
-            openingAngleQuoteWithSpacePattern, 
+            'opening_angle_quote_with_space',
+            openingAngleQuoteWithSpacePattern,
             '<per_mil_with_space'
         )
         self.replacements.add(
-            'closing_angle_quote_with_space', 
-            closingAngleQuoteWithSpacePattern, 
+            'closing_angle_quote_with_space',
+            closingAngleQuoteWithSpacePattern,
             '<opening_angle_quote_with_space'
         )
 
@@ -120,8 +123,8 @@ class FrenchTypographyExtension(markdown.extensions.Extension):
             'opening_angle_quotes', openingAngleQuotesPattern, '_begin'
         )
         self.replacements.add(
-            'closing_angle_quotes', 
-            closingAngleQuotesPattern, 
+            'closing_angle_quotes',
+            closingAngleQuotesPattern,
             '>opening_angle_quotes'
         )
 
@@ -136,8 +139,8 @@ class FrenchTypographyExtension(markdown.extensions.Extension):
             'opening_angle_quotes', openingAngleQuotesPattern, '_begin'
         )
         self.replacements.add(
-            'closing_angle_quotes', 
-            closingAngleQuotesPattern, 
+            'closing_angle_quotes',
+            closingAngleQuotesPattern,
             '>opening_angle_quotes'
         )
 
@@ -180,6 +183,7 @@ class FrenchTypographyExtension(markdown.extensions.Extension):
         processing.inlinePatterns = self.replacements
         md.treeprocessors.add('french_typography', processing, '_end')
         md.ESCAPED_CHARS.extend(["'", "«", "»"])
+
 
 def makeExtension(*args, **kwargs):
     return FrenchTypographyExtension(*args, **kwargs)

--- a/markdown/extensions/french_typography.py
+++ b/markdown/extensions/french_typography.py
@@ -1,0 +1,185 @@
+# Gestion fine de la typographie française, du moins, ce qui peut être
+# automatisé, Lointainement inspiré de l’extension SmartyPants.
+
+import re
+import markdown
+from ..inlinepatterns import HtmlPattern
+
+class ReplacePattern(HtmlPattern):
+    def __init__(self, pattern, replacement, markdown):
+        """ Replace the pattern by a simple text. """
+        HtmlPattern.__init__(self, pattern)
+        self.replacement = replacement
+        self.markdown = markdown
+
+    def handleMatch(self, m):
+        return self.markdown.htmlStash.store(self.replacement, safe=True)
+
+class ReplaceWithSpacePattern(HtmlPattern):
+    def __init__(self, pattern, replacement, markdown):
+        """ Replace the pattern by a simple text. """
+        HtmlPattern.__init__(self, pattern)
+        self.replacement = replacement
+        self.markdown = markdown
+
+    def handleMatch(self, m):
+        space = m.group(2)
+        replacement = self.replacement + space
+        return self.markdown.htmlStash.store(replacement, safe=True)
+
+class FrenchTypographyExtension(markdown.extensions.Extension):
+    def __init__(self, *args, **kwargs):
+        self.config = {
+            'apostrophes': [True, 'Typographic apostrophes'],
+            'em_dashes': [True, 'Em dashes'],
+            'en_dashes': [True, 'En dashes'],
+            'unbreakable_spaces': [True, 'Unbreakable spaces'],
+            'angle_quotes': [True, 'Angle quotes'],
+            'per_mil': [True, 'Per mil symbol'],
+            'ellipses': [True, 'Ellipses'],
+        }
+        super(FrenchTypographyExtension, self).__init__(*args, **kwargs)
+
+    def replaceApostrophes(self, md):
+        apostrophesPattern = ReplacePattern("'", "&rsquo;", md)
+        self.replacements.add('apostrophes', apostrophesPattern, '_begin')
+
+    def replaceEmDashes(self, md):
+        emDashesPattern = ReplacePattern(r'(?<!-)---(?!-)', "&mdash;", md)
+        self.replacements.add('em_dashes', emDashesPattern, '_begin')
+
+    def replaceEnDashes(self, md):
+        enDashesPattern = ReplacePattern(
+            r'(?<!-)--(?!-)', "&ndash;", md
+        )
+        self.replacements.add(
+            'en_dashes', enDashesPattern, '_begin'
+        )
+
+    def replaceSpaces(self, md):
+        semicolonWithSpacePattern = ReplaceWithSpacePattern(
+            r' ;([\s]|$)', "&#x202F;;", md
+        )
+        colonWithSpacePattern = ReplaceWithSpacePattern(
+            r' :([\s]|$)', "&#x202F;:", md
+        )
+        interrogationWithSpacePattern = ReplacePattern(" \?", "&#x202F;?", md)
+        exclamationWithSpacePattern = ReplacePattern(" !", "&#x202F;!", md)
+        perCentWithSpacePattern = ReplacePattern(" %", "&nbsp;%", md)
+        perMilWithSpacePattern = ReplacePattern(" ‰", "&nbsp;&permil;", md)
+        openingAngleQuoteWithSpacePattern = ReplacePattern(
+            "« ", "&laquo;&nbsp;", md
+        )
+        closingAngleQuoteWithSpacePattern = ReplacePattern(
+            " »", "&nbsp;&raquo;", md
+        )
+
+        self.replacements.add(
+            'semicolon_with_space', semicolonWithSpacePattern, '_end'
+        )
+        self.replacements.add(
+            'colon_with_space', 
+            colonWithSpacePattern, 
+            '<semicolon_with_space'
+        )
+        self.replacements.add(
+            'interrogation_mark_with_space', 
+            interrogationWithSpacePattern, 
+            '<colon_with_space'
+        )
+        self.replacements.add(
+            'exclamation_mark_with_space', 
+            exclamationWithSpacePattern, 
+            '<interrogation_mark_with_space'
+        )
+        self.replacements.add(
+            'per_cent_with_space', 
+            perCentWithSpacePattern, 
+            '<exclamation_mark_with_space'
+        )
+        self.replacements.add(
+            'per_mil_with_space', 
+            perMilWithSpacePattern, 
+            '<per_cent_with_space'
+        )
+        self.replacements.add(
+            'opening_angle_quote_with_space', 
+            openingAngleQuoteWithSpacePattern, 
+            '<per_mil_with_space'
+        )
+        self.replacements.add(
+            'closing_angle_quote_with_space', 
+            closingAngleQuoteWithSpacePattern, 
+            '<opening_angle_quote_with_space'
+        )
+
+    def replaceAngleQuotes(self, md):
+        openingAngleQuotesPattern = ReplacePattern(r'\<\<', "&laquo;", md)
+        closingAngleQuotesPattern = ReplacePattern(r'\>\>', "&raquo;", md)
+        self.replacements.add(
+            'opening_angle_quotes', openingAngleQuotesPattern, '_begin'
+        )
+        self.replacements.add(
+            'closing_angle_quotes', 
+            closingAngleQuotesPattern, 
+            '>opening_angle_quotes'
+        )
+
+    def replaceAngleQuotesWithSpaces(self, md):
+        openingAngleQuotesPattern = ReplacePattern(
+            r'\<\< ', "&laquo;&nbsp;", md
+        )
+        closingAngleQuotesPattern = ReplacePattern(
+            r' \>\>', "&nbsp;&raquo;", md
+        )
+        self.replacements.add(
+            'opening_angle_quotes', openingAngleQuotesPattern, '_begin'
+        )
+        self.replacements.add(
+            'closing_angle_quotes', 
+            closingAngleQuotesPattern, 
+            '>opening_angle_quotes'
+        )
+
+    def replacePerMil(self, md):
+        perMilPattern = ReplacePattern("%o", "&permil;", md)
+        self.replacements.add('per_mil', perMilPattern, '_begin')
+
+    def replacePerMilWithSpace(self, md):
+        perMilPattern = ReplacePattern(" %o", "&nbsp;&permil;", md)
+        self.replacements.add('per_mil', perMilPattern, '_begin')
+
+    def replaceEllipses(self, md):
+        ellipsesPattern = ReplacePattern(
+            r'(?<!\.)\.{3}(?!\.)', "&hellip;", md
+        )
+        self.replacements.add('ellipses', ellipsesPattern, '_begin')
+
+    def extendMarkdown(self, md, md_globals):
+        configs = self.getConfigs()
+        self.replacements = markdown.odict.OrderedDict()
+        if configs['apostrophes']:
+            self.replaceApostrophes(md)
+        if configs['em_dashes']:
+            self.replaceEmDashes(md)
+        if configs['en_dashes']:
+            self.replaceEnDashes(md)
+        if configs['unbreakable_spaces']:
+            self.replaceSpaces(md)
+        if configs['angle_quotes']:
+            self.replaceAngleQuotes(md)
+        if configs['angle_quotes'] and configs['unbreakable_spaces']:
+            self.replaceAngleQuotesWithSpaces(md)
+        if configs['per_mil']:
+            self.replacePerMil(md)
+        if configs['per_mil'] and configs['unbreakable_spaces']:
+            self.replacePerMilWithSpace(md)
+        if configs['ellipses']:
+            self.replaceEllipses(md)
+        processing = markdown.treeprocessors.InlineProcessor(md)
+        processing.inlinePatterns = self.replacements
+        md.treeprocessors.add('french_typography', processing, '_end')
+        md.ESCAPED_CHARS.extend(["'", "«", "»"])
+
+def makeExtension(*args, **kwargs):
+    return FrenchTypographyExtension(*args, **kwargs)

--- a/markdown/extensions/french_typography.py
+++ b/markdown/extensions/french_typography.py
@@ -69,12 +69,14 @@ class FrenchTypographyExtension(markdown.extensions.Extension):
         interrogationWithSpacePattern = ReplacePattern(" \?", "&#x202F;?", md)
         exclamationWithSpacePattern = ReplacePattern(" !", "&#x202F;!", md)
         perCentWithSpacePattern = ReplacePattern(" %", "&nbsp;%", md)
-        perMilWithSpacePattern = ReplacePattern(" ‰", "&nbsp;&permil;", md)
+        perMilWithSpacePattern = ReplacePattern(
+            b' \xe2\x80\xb0'.decode('utf-8'), "&nbsp;&permil;", md
+        )
         openingAngleQuoteWithSpacePattern = ReplacePattern(
-            "« ", "&laquo;&nbsp;", md
+            b'\xc2\xab '.decode('utf-8'), "&laquo;&nbsp;", md
         )
         closingAngleQuoteWithSpacePattern = ReplacePattern(
-            " »", "&nbsp;&raquo;", md
+            b' \xc2\xbb'.decode('utf-8'), "&nbsp;&raquo;", md
         )
 
         self.replacements.add(

--- a/markdown/extensions/zds.py
+++ b/markdown/extensions/zds.py
@@ -43,7 +43,7 @@ from .grid_tables import GridTableExtension
 from .comments import CommentsExtension
 from .smartLegend import SmartLegendExtension
 from .headerDec import DownHeaderExtension
-from .smarty import SmartyExtension
+from .french_typography import FrenchTypographyExtension
 from .codehilite import CodeHiliteExtension
 
 
@@ -69,7 +69,7 @@ class ZdsExtension(Extension):
         sub_ext = SubSuperscriptExtension()  # Sub and Superscript support
         del_ext = DelExtension()  # Del support
         urlize_ext = UrlizeExtension()  # Autolink support
-        sm_ext = SmartyExtension(smart_quotes=False)
+        typo_ext = FrenchTypographyExtension()  # French typography
         if not self.inline:
             mathjax_ext = MathJaxExtension()  # MathJax support
             kbd_ext = KbdExtension()  # Keyboard support
@@ -98,7 +98,7 @@ class ZdsExtension(Extension):
         exts = [sub_ext,  # Subscript support
                 del_ext,  # Del support
                 urlize_ext,  # Autolink support
-                sm_ext,
+                typo_ext,  # French typography
                 ]
         if not self.inline:
             exts.extend(['markdown.extensions.abbr',  # Abbreviation support, included in python-markdown

--- a/tests/zds/extensions/urlize.html
+++ b/tests/zds/extensions/urlize.html
@@ -8,15 +8,15 @@
 <p>Voici mon super lien qui termine une phrase <a href="http://www.google.fr">http://www.google.fr</a>.</p>
 <p><a href="https://fr.wikipedia.org/wiki/Compactifié_d'Alexandrov">https://fr.wikipedia.org/wiki/Compactifié_d'Alexandrov</a></p>
 <p><a href="https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov">https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov</a></p>
-<p>javascript:alert%28'Hello%20world!'%29</p>
+<p>javascript:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
 <p>vbscript:msgbox%28%22Hello%20world!%22%29</p>
-<p>livescript:alert%28'Hello%20world!'%29</p>
+<p>livescript:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
 <p>mocha:[code])</p>
-<p>jAvAsCrIpT:alert%28'Hello%20world!'%29</p>
-<p>ja&#32;vas&#32;cr&#32;ipt:alert%28'Hello%20world!'%29</p>
-<p>ja&#00032;vas&#32;cr&#32;ipt:alert%28'Hello%20world!'%29</p>
-<p>ja&#x00020;vas&#32;cr&#32;ipt:alert%28'Hello%20world!'%29</p>
-<p>ja%09&#x20;%0Avas&#32;cr&#x0a;ipt:alert%28'Hello%20world!'%29</p>
-<p>ja%20vas%20cr%20ipt:alert%28'Hello%20world!'%29</p>
-<p>live%20script:alert%28'Hello%20world!'%29</p>
-<p>javascript:alert%29'XSS'%29</p>
+<p>jAvAsCrIpT:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
+<p>ja&#32;vas&#32;cr&#32;ipt:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
+<p>ja&#00032;vas&#32;cr&#32;ipt:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
+<p>ja&#x00020;vas&#32;cr&#32;ipt:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
+<p>ja%09&#x20;%0Avas&#32;cr&#x0a;ipt:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
+<p>ja%20vas%20cr%20ipt:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
+<p>live%20script:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
+<p>javascript:alert%29&rsquo;XSS&rsquo;%29</p>

--- a/tests/zds/extensions/urlize.html
+++ b/tests/zds/extensions/urlize.html
@@ -8,15 +8,15 @@
 <p>Voici mon super lien qui termine une phrase <a href="http://www.google.fr">http://www.google.fr</a>.</p>
 <p><a href="https://fr.wikipedia.org/wiki/Compactifié_d'Alexandrov">https://fr.wikipedia.org/wiki/Compactifié_d'Alexandrov</a></p>
 <p><a href="https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov">https://fr.wikipedia.org/wiki/Compactifi%C3%A9_d%27Alexandrov</a></p>
-<p>javascript:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
+<p>javascript:alert%28'Hello%20world!'%29</p>
 <p>vbscript:msgbox%28%22Hello%20world!%22%29</p>
-<p>livescript:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
+<p>livescript:alert%28'Hello%20world!'%29</p>
 <p>mocha:[code])</p>
-<p>jAvAsCrIpT:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
-<p>ja&#32;vas&#32;cr&#32;ipt:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
-<p>ja&#00032;vas&#32;cr&#32;ipt:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
-<p>ja&#x00020;vas&#32;cr&#32;ipt:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
-<p>ja%09&#x20;%0Avas&#32;cr&#x0a;ipt:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
-<p>ja%20vas%20cr%20ipt:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
-<p>live%20script:alert%28&rsquo;Hello%20world!&rsquo;%29</p>
-<p>javascript:alert%29&rsquo;XSS&rsquo;%29</p>
+<p>jAvAsCrIpT:alert%28'Hello%20world!'%29</p>
+<p>ja&#32;vas&#32;cr&#32;ipt:alert%28'Hello%20world!'%29</p>
+<p>ja&#00032;vas&#32;cr&#32;ipt:alert%28'Hello%20world!'%29</p>
+<p>ja&#x00020;vas&#32;cr&#32;ipt:alert%28'Hello%20world!'%29</p>
+<p>ja%09&#x20;%0Avas&#32;cr&#x0a;ipt:alert%28'Hello%20world!'%29</p>
+<p>ja%20vas%20cr%20ipt:alert%28'Hello%20world!'%29</p>
+<p>live%20script:alert%28'Hello%20world!'%29</p>
+<p>javascript:alert%29'XSS'%29</p>

--- a/tests/zds/extensions/video.html
+++ b/tests/zds/extensions/video.html
@@ -10,5 +10,5 @@
 <iframe allowfullscreen="true" frameborder="0" height="560" src="https://jsfiddle.net/zgjhjv9j/1/embedded/result,js,html,css/" width="560"></iframe>
 <iframe allowfullscreen="true" frameborder="0" height="315" src="https://www.youtube.com/embed/1Bh4DZ2xGmw" width="560"></iframe>
 <iframe allowfullscreen="true" frameborder="0" height="349" src="http://player.ina.fr/player/embed/MAN9062216517/1/1b0bd203fbcd702f9bc9b10ac3d0fc21/560/315/1/148db8" width="620"></iframe>
-<p>This one should not be allowed :</p>
+<p>This one should not be allowed:</p>
 <p>!(http://jsfiddle.net/Sandhose/BcKhe/)</p>

--- a/tests/zds/extensions/video.txt
+++ b/tests/zds/extensions/video.txt
@@ -23,6 +23,6 @@ Test video
 
 !(http://www.ina.fr/video/MAN9062216517/qui-a-vole-le-bolero-de-ravel-e01-la-naissance-du-bolero-et-la-mort-de-ravel-video.html)
 
-This one should not be allowed :
+This one should not be allowed:
 
 !(http://jsfiddle.net/Sandhose/BcKhe/)

--- a/tests/zds/extensions/video_extra.html
+++ b/tests/zds/extensions/video_extra.html
@@ -1,6 +1,6 @@
 <h1>Test video extra</h1>
 <iframe allowfullscreen="true" frameborder="0" height="100%" src="https://www.youtube.com/embed/BpJKvrjLUp0" width="100%"></iframe>
-<p>These ones should not be allowed by config :</p>
+<p>These ones should not be allowed by config:</p>
 <p>!(http://jsfiddle.net/Sandhose/BcKhe/1/)</p>
 <p>!(http://jsfiddle.net/zgjhjv9j/)</p>
 <p>!(http://jsfiddle.net/zgjhjv9j/1/)</p>

--- a/tests/zds/extensions/video_extra.txt
+++ b/tests/zds/extensions/video_extra.txt
@@ -3,7 +3,7 @@ Test video extra
 
 !(https://www.youtube.com/watch?v=BpJKvrjLUp0)
 
-These ones should not be allowed by config :
+These ones should not be allowed by config:
 
 !(http://jsfiddle.net/Sandhose/BcKhe/1/)
 

--- a/tests/zds/rediger_sur_zds_part1.html
+++ b/tests/zds/rediger_sur_zds_part1.html
@@ -1,5 +1,5 @@
 <h3>Paragraphes</h3>
-<p>Les paragraphes s'écrivent naturellement, en sautant une ligne :</p>
+<p>Les paragraphes s&rsquo;écrivent naturellement, en sautant une ligne&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Ceci est mon premier paragraphe.
@@ -8,7 +8,7 @@ Ceci est mon second paragraphe.
 </pre></div>
 </td></tr></table>
 
-<p>Tout comme avec le Markdown standard, on change de paragraphe en <strong>sautant une ligne</strong>. Un simple retour à la ligne ne suffit donc pas et sera interprété comme un simple espace :</p>
+<p>Tout comme avec le Markdown standard, on change de paragraphe en <strong>sautant une ligne</strong>. Un simple retour à la ligne ne suffit donc pas et sera interprété comme un simple espace&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -21,9 +21,9 @@ Ceci est mon second paragraphe.
 
 <p>Si vraiment vous tenez à revenir à la ligne sans changer de paragraphe, comme ceci<br>
 par exemple, alors il suffit de terminer la première ligne par deux espaces.</p>
-<p>De plus, le Markdown standard autorise l'insertion de HTML, mais pour des raisons de sécurité nous avons choisi de ne pas laisser cette possibilité. Si vous écrivez du HTML, celui-ci apparaitra donc tel quel dans votre texte.</p>
+<p>De plus, le Markdown standard autorise l&rsquo;insertion de HTML, mais pour des raisons de sécurité nous avons choisi de ne pas laisser cette possibilité. Si vous écrivez du HTML, celui-ci apparaitra donc tel quel dans votre texte.</p>
 <h3>Titres</h3>
-<p>Les titres sont précédés d'un ou plusieurs croisillons suivant le niveau hiérarchique voulu. Ainsi un titre de premier niveau s'écrit avec un seul croisillon, un titre de deuxième niveau avec deux croisillons, etc.</p>
+<p>Les titres sont précédés d&rsquo;un ou plusieurs croisillons suivant le niveau hiérarchique voulu. Ainsi un titre de premier niveau s&rsquo;écrit avec un seul croisillon, un titre de deuxième niveau avec deux croisillons, etc.</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -40,10 +40,10 @@ par exemple, alors il suffit de terminer la première ligne par deux espaces.</p
 </pre></div>
 </td></tr></table>
 
-<p>Quatre niveaux hiérarchiques sont possibles. J'attire d'ailleurs votre attention sur ce point car il est très important de donner la bonne hiérarchie à vos titres lorsque vous rédigerez vos tutoriels.</p>
+<p>Quatre niveaux hiérarchiques sont possibles. J&rsquo;attire d&rsquo;ailleurs votre attention sur ce point car il est très important de donner la bonne hiérarchie à vos titres lorsque vous rédigerez vos tutoriels.</p>
 <h3>Emphases</h3>
-<p>Les emphases permettent de mettre un morceau de votre texte en valeur. Deux types d'emphases sont disponibles : l'italique et le gras.</p>
-<p>Pour mettre du texte en <em>italique</em>, utilisez l'astérisque ou le souligné (<em>underscore</em>) :</p>
+<p>Les emphases permettent de mettre un morceau de votre texte en valeur. Deux types d&rsquo;emphases sont disponibles&#x202F;: l&rsquo;italique et le gras.</p>
+<p>Pour mettre du texte en <em>italique</em>, utilisez l&rsquo;astérisque ou le souligné (<em>underscore</em>)&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Le mot *italique* est en italique.
 </pre></div>
 </td></tr></table>
@@ -56,7 +56,7 @@ par exemple, alors il suffit de terminer la première ligne par deux espaces.</p
 <div class="warning ico-after">
 <p>Si la syntaxe avec underscore est utilisée en milieu de mot, alors le texte ne sera pas transformé. Ainsi <code>truc_bidule_mush</code> ne sera pas transformé alors que <code>truc*bidule*mush</code> le sera. Cela tient du fait que les expressions avec des underscores sont communes en informatique comme Mon_super_nom_de_fichier.txt par exemple.</p>
 </div>
-<p>Pour mettre du texte en <strong>gras</strong> le principe est le même, en doublant le symbole :</p>
+<p>Pour mettre du texte en <strong>gras</strong> le principe est le même, en doublant le symbole&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Le mot **gras** est en gras.
 </pre></div>
 </td></tr></table>
@@ -68,35 +68,35 @@ par exemple, alors il suffit de terminer la première ligne par deux espaces.</p
 
 <p>Par souci de simplicité et de lisibilité, vous ne pourrez pas mettre du texte en couleur, le souligner, changer sa taille ou bien encore en changer la police.</p>
 <h3>Barrer</h3>
-<p>Barrer du texte (<del>comme ceci</del>) se fait en utilisant deux tildes successifs avant et après la portion de texte concernée :</p>
+<p>Barrer du texte (<del>comme ceci</del>) se fait en utilisant deux tildes successifs avant et après la portion de texte concernée&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Le mot ~~barré~~ est barré.
 </pre></div>
 </td></tr></table>
 
-<p>Pour information, il s'agit de la syntaxe utilisée par Pandoc.</p>
+<p>Pour information, il s&rsquo;agit de la syntaxe utilisée par Pandoc.</p>
 <h3>Alignement du texte</h3>
-<p>Par défaut, le texte est bien évidemment aligné à gauche. Comme nous le verrons plus loin, certains éléments sont centrés automatiquement, comme les images seules dans leur paragraphe par exemple. Vous n'avez donc en général pas à vous soucier de l'alignement du texte : le site s'en charge pour vous.</p>
-<p>Dans les rares cas où vous souhaiteriez centrer volontairement un texte (si l'envie vous prenait d'écrire un poème par exemple), vous pourriez néanmoins utiliser la syntaxe ci-dessous :</p>
+<p>Par défaut, le texte est bien évidemment aligné à gauche. Comme nous le verrons plus loin, certains éléments sont centrés automatiquement, comme les images seules dans leur paragraphe par exemple. Vous n&rsquo;avez donc en général pas à vous soucier de l&rsquo;alignement du texte&#x202F;: le site s&rsquo;en charge pour vous.</p>
+<p>Dans les rares cas où vous souhaiteriez centrer volontairement un texte (si l&rsquo;envie vous prenait d&rsquo;écrire un poème par exemple), vous pourriez néanmoins utiliser la syntaxe ci-dessous&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>-&gt; Ce texte est centré. &lt;- 
 </pre></div>
 </td></tr></table>
 
-<p>Le texte est simplement entouré de deux petites flèches (tiret et chevron) de directions inversées. Pour aligner à droite, on utilise deux flèches dirigées vers la droite :</p>
+<p>Le texte est simplement entouré de deux petites flèches (tiret et chevron) de directions inversées. Pour aligner à droite, on utilise deux flèches dirigées vers la droite&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>-&gt; Ce texte est aligné à droite. -&gt; 
 </pre></div>
 </td></tr></table>
 
-<p>Il est impossible d'imbriquer des alignements. Cela n'aurait de toute façon pas de sens (comment aligner à droite un texte centré ?).</p>
-<p>Encore une fois, l'alignement est géré automatiquement dans la majorité des cas. N'en abusez pas, cela pourrait gêner la lecture.</p>
-<p>Enfin, sachez qu'il est impossible de justifier du texte sur le site.</p>
+<p>Il est impossible d&rsquo;imbriquer des alignements. Cela n&rsquo;aurait de toute façon pas de sens (comment aligner à droite un texte centré&#x202F;?).</p>
+<p>Encore une fois, l&rsquo;alignement est géré automatiquement dans la majorité des cas. N&rsquo;en abusez pas, cela pourrait gêner la lecture.</p>
+<p>Enfin, sachez qu&rsquo;il est impossible de justifier du texte sur le site.</p>
 <h3>Indices et exposants</h3>
 <p>Là encore, ce sont les syntaxes de Pandoc qui sont utilisées pour mettre en indice ou en exposant une portion de texte.</p>
-<p>On utilise l'accent circonflexe pour l'exposant. Si par exemple on veut écrire que 2<sup>10</sup> vaut 1024, alors on écrira :</p>
+<p>On utilise l&rsquo;accent circonflexe pour l&rsquo;exposant. Si par exemple on veut écrire que 2<sup>10</sup> vaut 1024, alors on écrira&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>2^10^ vaut 1024.
 </pre></div>
 </td></tr></table>
 
-<p>Pour l'indice, comme dans H<sub>2</sub>O par exemple, on utilise cette fois le tilde :</p>
+<p>Pour l&rsquo;indice, comme dans H<sub>2</sub>O par exemple, on utilise cette fois le tilde&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>La molécule de l&#39;eau est H~2~O.
 </pre></div>
 </td></tr></table>

--- a/tests/zds/rediger_sur_zds_part10.html
+++ b/tests/zds/rediger_sur_zds_part10.html
@@ -1,7 +1,7 @@
-<p>Si vous avez besoin d'écrire un caractère réservé entrant en conflit avec l'une des syntaxes décrites ici (l'astérisque par exemple), vous pouvez le faire en le précédent d'un antislash : <code>\*</code></p>
-<p>Enfin, vous pouvez mettre une partie de votre texte en commentaires en le mettant entre des balises spécifiques :</p>
+<p>Si vous avez besoin d&rsquo;écrire un caractère réservé entrant en conflit avec l&rsquo;une des syntaxes décrites ici (l&rsquo;astérisque par exemple), vous pouvez le faire en le précédent d&rsquo;un antislash&#x202F;: <code>\*</code></p>
+<p>Enfin, vous pouvez mettre une partie de votre texte en commentaires en le mettant entre des balises spécifiques&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Ceci est mon texte. &lt;--COMMENT Et ceci est une partie commentée. COMMENT--&gt; 
 </pre></div>
 </td></tr></table>
 
-<p>La partie commentée n'apparaîtra tout simplement pas dans le rendu final.</p>
+<p>La partie commentée n&rsquo;apparaîtra tout simplement pas dans le rendu final.</p>

--- a/tests/zds/rediger_sur_zds_part2.html
+++ b/tests/zds/rediger_sur_zds_part2.html
@@ -1,9 +1,9 @@
-<p>Vous pouvez utiliser deux types de liste :</p>
+<p>Vous pouvez utiliser deux types de liste&#x202F;:</p>
 <ul>
-<li>les listes non ordonnées (comme la présente) ;</li>
+<li>les listes non ordonnées (comme la présente)&#x202F;;</li>
 <li>les listes ordonnées par chiffres arabes.</li>
 </ul>
-<p>C'est peut-être la syntaxe la plus intuitive du Markdown ! Il suffit de matérialiser les puces par des tirets :</p>
+<p>C&rsquo;est peut-être la syntaxe la plus intuitive du Markdown&#x202F;! Il suffit de matérialiser les puces par des tirets&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>- Ma très belle ;
@@ -12,7 +12,7 @@
 </pre></div>
 </td></tr></table>
 
-<p>Ou bien par des chiffres :</p>
+<p>Ou bien par des chiffres&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>1. Mon premier.
@@ -22,7 +22,7 @@
 </td></tr></table>
 
 <p>Prenez simplement garde à bien sauter une ligne <strong>avant et après</strong> vos listes.</p>
-<p>Pour faire une sous-liste, indentez les puces imbriquées avec <strong>quatre</strong> espaces :</p>
+<p>Pour faire une sous-liste, indentez les puces imbriquées avec <strong>quatre</strong> espaces&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -33,11 +33,11 @@
 </pre></div>
 </td></tr></table>
 
-<p>On obtient ainsi : </p>
+<p>On obtient ainsi&#x202F;: </p>
 <ul>
-<li>Ma très belle ;</li>
-<li>liste ;<ul>
-<li>avec une sous-liste ;</li>
+<li>Ma très belle&#x202F;;</li>
+<li>liste&#x202F;;<ul>
+<li>avec une sous-liste&#x202F;;</li>
 </ul>
 </li>
 <li>à puces.</li>

--- a/tests/zds/rediger_sur_zds_part3.html
+++ b/tests/zds/rediger_sur_zds_part3.html
@@ -1,17 +1,17 @@
-<p>Il existe deux façons d'écrire des liens : avec ou sans texte d'ancrage.</p>
-<h3>Liens et emails avec texte d'ancrage</h3>
-<p>Pour faire un <a href="http://www.zestedesavoir.com" title="Zeste de Savoir">lien</a> sur un morceau de texte (qu'on appelle donc texte d'ancrage, ici le mot "lien"), on utilise la syntaxe suivante :</p>
+<p>Il existe deux façons d&rsquo;écrire des liens&#x202F;: avec ou sans texte d&rsquo;ancrage.</p>
+<h3>Liens et emails avec texte d&rsquo;ancrage</h3>
+<p>Pour faire un <a href="http://www.zestedesavoir.com" title="Zeste de Savoir">lien</a> sur un morceau de texte (qu&rsquo;on appelle donc texte d&rsquo;ancrage, ici le mot "lien"), on utilise la syntaxe suivante&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Pour faire un [lien](http://www.zestedesavoir.com &quot;Zeste de Savoir&quot;) sur un morceau de texte
 </pre></div>
 </td></tr></table>
 
-<p>Attention à ne pas mettre d'espace entre la partie concernant le texte d'ancrage (entre crochets) et la partie concernant l'URL (entre parenthèses).</p>
-<p>Le titre du lien (ici "Zeste de Savoir" entre guillemets) est optionnel. S'il est renseigné, il apparaît sur le lien au passage de la souris.</p>
-<p>Les emails peuvent s'écrire de la même façon que les liens. Pensez simplement à ajouter la mention "mailto:" :</p>
+<p>Attention à ne pas mettre d&rsquo;espace entre la partie concernant le texte d&rsquo;ancrage (entre crochets) et la partie concernant l&rsquo;URL (entre parenthèses).</p>
+<p>Le titre du lien (ici "Zeste de Savoir" entre guillemets) est optionnel. S&rsquo;il est renseigné, il apparaît sur le lien au passage de la souris.</p>
+<p>Les emails peuvent s&rsquo;écrire de la même façon que les liens. Pensez simplement à ajouter la mention "mailto:"&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Pour nous contacter, cliquez [ici](mailto:contact@monsite.com).
 </pre></div>
 </td></tr></table>
 
-<h3>Liens présentés sous forme d'URL ou d'email</h3>
-<p>Si vous ne souhaitez pas utiliser de texte d'ancrage et ainsi rendre une URL ou un email cliquable, alors vous n'avez rien à faire : URL et emails seront automatiquement cliquables.</p>
-<p>Pour les emails, vous n'avez donc même pas besoin de vous soucier du "mailto".</p>
+<h3>Liens présentés sous forme d&rsquo;URL ou d&rsquo;email</h3>
+<p>Si vous ne souhaitez pas utiliser de texte d&rsquo;ancrage et ainsi rendre une URL ou un email cliquable, alors vous n&rsquo;avez rien à faire&#x202F;: URL et emails seront automatiquement cliquables.</p>
+<p>Pour les emails, vous n&rsquo;avez donc même pas besoin de vous soucier du "mailto".</p>

--- a/tests/zds/rediger_sur_zds_part4.html
+++ b/tests/zds/rediger_sur_zds_part4.html
@@ -1,5 +1,5 @@
 <h3>Des tableaux simples</h3>
-<p>Pour faire un tableau, la façon la plus simple est encore de le dessiner, à l'aide de barres verticales et de tirets :</p>
+<p>Pour faire un tableau, la façon la plus simple est encore de le dessiner, à l&rsquo;aide de barres verticales et de tirets&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -14,7 +14,7 @@ Mathilde  | 35
 </pre></div>
 </td></tr></table>
 
-<p>L'exemple ci-dessus donnera donc :</p>
+<p>L&rsquo;exemple ci-dessus donnera donc&#x202F;:</p>
 <div class="table-wrapper">
 <table>
 <thead>
@@ -43,9 +43,9 @@ Mathilde  | 35
 </tbody>
 </table>
 </div>
-<p>Cette syntaxe est simple mais elle a ses limites : il est impossible de revenir à la ligne dans une cellule ou bien de fusionner des lignes ou des colonnes. Si vous avez vraiment besoin de faire cela, il vous faudra utiliser une autre syntaxe de tableau, plus lourde mais plus complète, comme nous allons le voir à présent.</p>
+<p>Cette syntaxe est simple mais elle a ses limites&#x202F;: il est impossible de revenir à la ligne dans une cellule ou bien de fusionner des lignes ou des colonnes. Si vous avez vraiment besoin de faire cela, il vous faudra utiliser une autre syntaxe de tableau, plus lourde mais plus complète, comme nous allons le voir à présent.</p>
 <h3>Tableaux complexes</h3>
-<p>Pour des tableaux plus complexes, dans lesquels vous pourrez notamment revenir à la ligne dans une cellule et fusionner des lignes ou colonnes, il vous faut utiliser la syntaxe dite « grid-table » :</p>
+<p>Pour des tableaux plus complexes, dans lesquels vous pourrez notamment revenir à la ligne dans une cellule et fusionner des lignes ou colonnes, il vous faut utiliser la syntaxe dite &laquo;&nbsp;grid-table&nbsp;&raquo;&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre> 1
  2
  3
@@ -78,7 +78,7 @@ Mathilde  | 35
 </pre></div>
 </td></tr></table>
 
-<p>Ce qui vous donnera :</p>
+<p>Ce qui vous donnera&#x202F;:</p>
 <div class="table-wrapper">
 <table>
 <thead>
@@ -139,12 +139,12 @@ too</p>
 </div>
 <h3>Légendes de tableaux</h3>
 <p>Quelle que soit la syntaxe utilisée, vous pouvez indiquer une légende à votre tableau en ajoutant une ligne <code>Table: Ma légende</code> juste en dessous du tableau.</p>
-<p>Le mot « Table » est optionnel, pas les deux-points. Il peut y avoir un espace entre « Table » et les deux-points.</p>
+<p>Le mot &laquo;&nbsp;Table&nbsp;&raquo; est optionnel, pas les deux-points. Il peut y avoir un espace entre &laquo;&nbsp;Table&nbsp;&raquo; et les deux-points.</p>
 <h3>Lignes horizontales</h3>
-<p>Pour tracer une ligne horizontale, le principe est le même : <em>dessinez-là</em>. La syntaxe est cette fois bien plus simple puisqu'elle n'est constituée que de trois tirets (ou plus, ça ne change rien au résultat) :</p>
+<p>Pour tracer une ligne horizontale, le principe est le même&#x202F;: <em>dessinez-là</em>. La syntaxe est cette fois bien plus simple puisqu&rsquo;elle n&rsquo;est constituée que de trois tirets (ou plus, ça ne change rien au résultat)&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>------
 </pre></div>
 </td></tr></table>
 
-<p>Voici le résultat :</p>
+<p>Voici le résultat&#x202F;:</p>
 <hr>

--- a/tests/zds/rediger_sur_zds_part5.html
+++ b/tests/zds/rediger_sur_zds_part5.html
@@ -1,18 +1,18 @@
-<p>Une formule mathématique s'écrit à l'aide d'expressions TeX Math, en l'entourant de deux caractères dollars <code>$$</code> :</p>
+<p>Une formule mathématique s&rsquo;écrit à l&rsquo;aide d&rsquo;expressions TeX Math, en l&rsquo;entourant de deux caractères dollars <code>$$</code>&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>$$a \cdot x^2 + b \cdot x + c = 0 \quad \Longrightarrow \quad x = \frac {-b \pm \sqrt{b^2 - 4ac}}{2a}$$
 </pre></div>
 </td></tr></table>
 
-<p>Ce qui donne :</p>
+<p>Ce qui donne&#x202F;:</p>
 <div class="mathjax-wrapper"><mathjax>$$a \cdot x^2 + b \cdot x + c = 0 \quad \Longrightarrow \quad x = \frac {-b \pm \sqrt{b^2 - 4ac}}{2a}$$</mathjax></div>
-<p>En faisant ainsi, votre formule est en mode <em>displayed</em> : elle est dans son propre paragrpahe et s'affiche en prenant ses aises. Ainsi les chiffres et autres symboles sont écrits en grande taille et sont facilement lisibles.</p>
-<p>Si vous voulez écrire votre formule au sein même d'un paragraphe (comme ceci : <span>$a \cdot x^2 + b \cdot x + c = 0$</span>), alors n'utilisez cette fois qu'un seul caractère dollar <code>$</code> avant et après votre formule. Par exemple :</p>
+<p>En faisant ainsi, votre formule est en mode <em>displayed</em>&#x202F;: elle est dans son propre paragrpahe et s&rsquo;affiche en prenant ses aises. Ainsi les chiffres et autres symboles sont écrits en grande taille et sont facilement lisibles.</p>
+<p>Si vous voulez écrire votre formule au sein même d&rsquo;un paragraphe (comme ceci&#x202F;: <span>$a \cdot x^2 + b \cdot x + c = 0$</span>), alors n&rsquo;utilisez cette fois qu&rsquo;un seul caractère dollar <code>$</code> avant et après votre formule. Par exemple&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Si vous voulez écrire votre formule au sein même d&#39;un paragraphe (comme ceci : $a \cdot x^2 + b \cdot x + c = 0$), alors n&#39;utilisez cette fois qu&#39;un seul caractère dollar `$` avant et après votre formule.
 </pre></div>
 </td></tr></table>
 
 <p>Comme pour les tableaux, vous pouvez mettre une légende à votre formule, en ajoutant une ligne <code>Equation: Ma légende</code> juste en dessous. Le mot-clé <code>Equation</code> est optionnel.</p>
-<p>Si vous souhaitez écrire deux symboles $ dans une même ligne, alors il vous faut <strong>échapper</strong> au moins l'un des deux (c'est-à-dire les faire précéder d'un antislash : \$) afin que le texte ne soit pas considéré comme une formule mathématique.</p>
+<p>Si vous souhaitez écrire deux symboles $ dans une même ligne, alors il vous faut <strong>échapper</strong> au moins l&rsquo;un des deux (c&rsquo;est-à-dire les faire précéder d&rsquo;un antislash&#x202F;: \$) afin que le texte ne soit pas considéré comme une formule mathématique.</p>
 <div class="information ico-after">
-<p>Pour en savoir plus sur l'utilisation des expressions mathématiques, vous pouvez consulter le tutoriel dédié: <a href="http://zestedesavoir.com/tutoriels/202/comment-rediger-des-maths-sur-zeste-de-savoir/">Comment rédiger des maths sur Zeste de Savoir ? </a></p>
+<p>Pour en savoir plus sur l&rsquo;utilisation des expressions mathématiques, vous pouvez consulter le tutoriel dédié&#x202F;: <a href="http://zestedesavoir.com/tutoriels/202/comment-rediger-des-maths-sur-zeste-de-savoir/">Comment rédiger des maths sur Zeste de Savoir&#x202F;? </a></p>
 </div>

--- a/tests/zds/rediger_sur_zds_part5.txt
+++ b/tests/zds/rediger_sur_zds_part5.txt
@@ -21,4 +21,4 @@ Comme pour les tableaux, vous pouvez mettre une légende à votre formule, en aj
 Si vous souhaitez écrire deux symboles $ dans une même ligne, alors il vous faut **échapper** au moins l'un des deux (c'est-à-dire les faire précéder d'un antislash : \$) afin que le texte ne soit pas considéré comme une formule mathématique.
 
 [[information]]
-| Pour en savoir plus sur l'utilisation des expressions mathématiques, vous pouvez consulter le tutoriel dédié: [Comment rédiger des maths sur Zeste de Savoir ? ](http://zestedesavoir.com/tutoriels/202/comment-rediger-des-maths-sur-zeste-de-savoir/)
+| Pour en savoir plus sur l'utilisation des expressions mathématiques, vous pouvez consulter le tutoriel dédié : [Comment rédiger des maths sur Zeste de Savoir ? ](http://zestedesavoir.com/tutoriels/202/comment-rediger-des-maths-sur-zeste-de-savoir/)

--- a/tests/zds/rediger_sur_zds_part6.html
+++ b/tests/zds/rediger_sur_zds_part6.html
@@ -1,5 +1,5 @@
 <h3>Bloc de code</h3>
-<p>Il n'est pas rare d'illustrer son propos d'un petit exemple de code :</p>
+<p>Il n&rsquo;est pas rare d&rsquo;illustrer son propos d&rsquo;un petit exemple de code&#x202F;:</p>
 <figure><table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3</pre></div></td><td class="code"><div class="codehilite"><pre><span></span><span class="ch">#!/usr/bin/env python3</span>
@@ -9,7 +9,7 @@
 </td></tr></table>
 
 <figcaption><p>Mon exemple de code</p></figcaption></figure><p>Pour cela, il existe plusieurs solutions.</p>
-<p>Première solution : entourer votre code d'au moins trois accents graves ``` (<kbd>Alt Gr</kbd> + <kbd>7</kbd>), avant et après : </p>
+<p>Première solution&#x202F;: entourer votre code d&rsquo;au moins trois accents graves ``` (<kbd>Alt Gr</kbd> + <kbd>7</kbd>), avant et après&#x202F;: </p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -22,7 +22,7 @@ print(&quot;Hello, World!&quot;)
 </pre></div>
 </td></tr></table>
 
-<p>Le langage utilisé sera détecté automatiquement et donc coloré en conséquence. Si tel n'est pas le cas, vous pouvez forcer le langage en l'indiquant à la suite des caractères ouvrants :</p>
+<p>Le langage utilisé sera détecté automatiquement et donc coloré en conséquence. Si tel n&rsquo;est pas le cas, vous pouvez forcer le langage en l&rsquo;indiquant à la suite des caractères ouvrants&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -35,8 +35,8 @@ print(&quot;Hello, World!&quot;)
 </pre></div>
 </td></tr></table>
 
-<p>La liste des langages supportés est celle de <strong>pygment</strong>, vous la trouverez <a href="http://pygments.org/languages" title="Langages pygment">ici</a>. Les mots-clés à insérer pour déclencher la coloration sont les « short names » disponibles sur <a href="http://pygments.org/docs/lexers" title="Mots-clé pygment">cette page</a>.</p>
-<p>Seconde solution, faites précéder chaque ligne de quatre espaces ou bien d'une tabulation :</p>
+<p>La liste des langages supportés est celle de <strong>pygment</strong>, vous la trouverez <a href="http://pygments.org/languages" title="Langages pygment">ici</a>. Les mots-clés à insérer pour déclencher la coloration sont les &laquo;&nbsp;short names&nbsp;&raquo; disponibles sur <a href="http://pygments.org/docs/lexers" title="Mots-clé pygment">cette page</a>.</p>
+<p>Seconde solution, faites précéder chaque ligne de quatre espaces ou bien d&rsquo;une tabulation&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>    #!/usr/bin/env python3
@@ -45,7 +45,7 @@ print(&quot;Hello, World!&quot;)
 </pre></div>
 </td></tr></table>
 
-<p>Pour forcer le langage, utilisez cette fois trois symboles de deux-points de suite :</p>
+<p>Pour forcer le langage, utilisez cette fois trois symboles de deux-points de suite&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -58,7 +58,7 @@ print(&quot;Hello, World!&quot;)
 
 <p>Là encore, vous pouvez mettre une légende à votre bloc de code en ajoutant, juste en dessous du bloc, une ligne <code>Code:Votre légende</code>.</p>
 <h3>Mise en évidence de lignes de code</h3>
-<p>Mettre en évidence une portion de code permet d'appuyer votre explication :</p>
+<p>Mettre en évidence une portion de code permet d&rsquo;appuyer votre explication&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -75,7 +75,7 @@ print(&quot;Hello, World!&quot;)
 </pre></div>
 </td></tr></table>
 
-<p>Après le nom du langage, indiquez simplement les lignes à surligner avec la mention <code>hl_lines</code>. Vous pouvez surligner les lignes unes à unes ou par groupes. Le syntaxe est la suivante :</p>
+<p>Après le nom du langage, indiquez simplement les lignes à surligner avec la mention <code>hl_lines</code>. Vous pouvez surligner les lignes unes à unes ou par groupes. Le syntaxe est la suivante&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -97,7 +97,7 @@ print &quot;Bonjour, $nom !\n&quot;;
 </td></tr></table>
 
 <h3>Début de la numérotation</h3>
-<p>Il est possible de spécifier le début de numération. Par exemple :</p>
+<p>Il est possible de spécifier le début de numération. Par exemple&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>10
 11
 12
@@ -110,7 +110,7 @@ print &quot;Bonjour, $nom !\n&quot;;
 
 <p>On utilise le mot-clé <code>linenostart</code> de la même façon que le <code>hl_lines</code> vu précédemment.</p>
 <h3>Code inline</h3>
-<p>Enfin, si vous souhaitez insérer un petit élément de code dans votre phrase (comme <code>print</code> par exemple), alors un seul accent grave autour du mot suffira :</p>
+<p>Enfin, si vous souhaitez insérer un petit élément de code dans votre phrase (comme <code>print</code> par exemple), alors un seul accent grave autour du mot suffira&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>comme `print` par exemple
 </pre></div>
 </td></tr></table>

--- a/tests/zds/rediger_sur_zds_part7.html
+++ b/tests/zds/rediger_sur_zds_part7.html
@@ -1,11 +1,11 @@
 <h3>Images</h3>
-<p>L'insertion d'une image ressemble à celle d'un lien, à ceci près que le texte d'ancrage doit être remplacé par un texte alternatif :</p>
+<p>L&rsquo;insertion d&rsquo;une image ressemble à celle d&rsquo;un lien, à ceci près que le texte d&rsquo;ancrage doit être remplacé par un texte alternatif&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>![Logo Creative Commons](http://mirrors.creativecommons.org/presskit/logos/cc.logo.png)
 </pre></div>
 </td></tr></table>
 
-<p>Il y a une petite différence de comportement selon que vous placiez votre image seule dans un paragraphe (ou dans un bloc de texte type citation, information, secret, etc.) ou bien au cours d'une phrase dans votre texte.</p>
-<p>Lorsque l'image est seule, alors elle est présentée comme figure <strong>avec légende</strong>. Ainsi, si on prend l'exemple suivant :</p>
+<p>Il y a une petite différence de comportement selon que vous placiez votre image seule dans un paragraphe (ou dans un bloc de texte type citation, information, secret, etc.) ou bien au cours d&rsquo;une phrase dans votre texte.</p>
+<p>Lorsque l&rsquo;image est seule, alors elle est présentée comme figure <strong>avec légende</strong>. Ainsi, si on prend l&rsquo;exemple suivant&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -18,21 +18,21 @@ Bla bla bla encore
 </pre></div>
 </td></tr></table>
 
-<p>Alors le rendu sera la suivant :</p>
+<p>Alors le rendu sera la suivant&#x202F;:</p>
 <hr>
 <p>Bla bla bla</p>
 <p><figure><img alt="" src="http://mirrors.creativecommons.org/presskit/logos/cc.logo.png"><figcaption>Logo Creative Commons</figcaption></figure></p>
 <p>Bla bla bla encore</p>
 <hr>
-<p>Si en revanche l'image est placée au cours d'un texte, alors le comportement sera plus classique et l'image apparaîtra naturellement dans la phrase :</p>
+<p>Si en revanche l&rsquo;image est placée au cours d&rsquo;un texte, alors le comportement sera plus classique et l&rsquo;image apparaîtra naturellement dans la phrase&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Appuyez sur l&#39;icône ![Icône machintruc](icone.png) et admirez le résultat.
 </pre></div>
 </td></tr></table>
 
 <div class="warning ico-after">
-<p>Dans tous les cas, le texte alternatif <strong>doit</strong> être renseigné. Il sert à apporter la même information que l'image si celle-ci ne peut être chargée ou bien ne peut être vue (notamment pour les synthétiseurs vocaux pour les non-voyants).</p>
+<p>Dans tous les cas, le texte alternatif <strong>doit</strong> être renseigné. Il sert à apporter la même information que l&rsquo;image si celle-ci ne peut être chargée ou bien ne peut être vue (notamment pour les synthétiseurs vocaux pour les non-voyants).</p>
 </div>
-<p>Il est possible de définir à la fois un texte alternatif et une légende, en utilisant le mot-clé <code>Figure</code> de la même façon que pour les légendes de tableaux ou blocs de code :</p>
+<p>Il est possible de définir à la fois un texte alternatif et une légende, en utilisant le mot-clé <code>Figure</code> de la même façon que pour les légendes de tableaux ou blocs de code&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -49,8 +49,8 @@ Bla bla bla
 
 <p>Ainsi, le texte alternatif et la légende sont bien différents.</p>
 <h3>Vidéos</h3>
-<p>Les vidéos doivent être insérées avec une syntaxe dédié : <code>!(URL Vidéo)</code>. Elles ne peuvent être inline (au sein d'une phrase). </p>
-<p>Pour insérer une vidéo on peut donc faire :</p>
+<p>Les vidéos doivent être insérées avec une syntaxe dédié&#x202F;: <code>!(URL Vidéo)</code>. Elles ne peuvent être inline (au sein d&rsquo;une phrase). </p>
+<p>Pour insérer une vidéo on peut donc faire&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -63,7 +63,7 @@ Bla bla bla
 </pre></div>
 </td></tr></table>
 
-<p>ou avec une légende :</p>
+<p>ou avec une légende&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -78,17 +78,17 @@ Bla bla bla
 </pre></div>
 </td></tr></table>
 
-<p>Par exemple :</p>
+<p>Par exemple&#x202F;:</p>
 <figure><iframe allowfullscreen="true" frameborder="0" height="315" src="https://www.youtube.com/embed/oavMtUWDBTM" width="560"></iframe>
 <figcaption><p>Ma super légende</p></figcaption></figure><h3>Touches</h3>
-<p>Pour représenter une touche, utilisez deux barres verticales avant et après le nom de la touche :</p>
+<p>Pour représenter une touche, utilisez deux barres verticales avant et après le nom de la touche&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Utilisez ||Ctrl|| + ||C|| pour copier.
 </pre></div>
 </td></tr></table>
 
 <p>Vous pouvez bien sûr mettre <kbd>ce que vous voulez</kbd> comme nom de touche.</p>
 <h3>Smileys</h3>
-<p>Que serait un forum sans smileys ? Un forum plus agréable ? Peut-être. Il n'empêche que les fameux smileys sont incontournables. Sur ZdS, les smileys que vous écrivez seront automatiquement transformés en image. Ci-dessous une liste (non exhaustive) des smileys disponibles :</p>
+<p>Que serait un forum sans smileys&#x202F;? Un forum plus agréable&#x202F;? Peut-être. Il n&rsquo;empêche que les fameux smileys sont incontournables. Sur ZdS, les smileys que vous écrivez seront automatiquement transformés en image. Ci-dessous une liste (non exhaustive) des smileys disponibles&#x202F;:</p>
 <div class="table-wrapper">
 <table>
 <thead>
@@ -201,4 +201,4 @@ Bla bla bla
 </tbody>
 </table>
 </div>
-<p>N'oubliez pas : l'abus de smileys est dangereux pour votre santé et celle de vos proches, utilisez-les avec modération. <img alt=";)" src="/static/smileys/clin.png"></p>
+<p>N&rsquo;oubliez pas&#x202F;: l&rsquo;abus de smileys est dangereux pour votre santé et celle de vos proches, utilisez-les avec modération. <img alt=";)" src="/static/smileys/clin.png"></p>

--- a/tests/zds/rediger_sur_zds_part8.html
+++ b/tests/zds/rediger_sur_zds_part8.html
@@ -1,10 +1,10 @@
 <h3>Balises attention, erreur, information, question et secret</h3>
-<p>Les tutoriels et articles de ZdS sont parsemés de balises telles que la balise "information" :</p>
+<p>Les tutoriels et articles de ZdS sont parsemés de balises telles que la balise "information"&#x202F;:</p>
 <div class="information ico-after">
-<p>Ceci est une balise d'information.</p>
-<p>Cool, non ?</p>
+<p>Ceci est une balise d&rsquo;information.</p>
+<p>Cool, non&#x202F;?</p>
 </div>
-<p>Elle se fait avec la syntaxe suivante :</p>
+<p>Elle se fait avec la syntaxe suivante&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -15,7 +15,7 @@
 </pre></div>
 </td></tr></table>
 
-<p>Ou dans sa version raccourcie :</p>
+<p>Ou dans sa version raccourcie&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -26,7 +26,7 @@
 </pre></div>
 </td></tr></table>
 
-<p>Les balises disponibles sont : </p>
+<p>Les balises disponibles sont&#x202F;: </p>
 <ul>
 <li>attention</li>
 <li>erreur</li>
@@ -34,14 +34,14 @@
 <li>question</li>
 <li>secret</li>
 </ul>
-<p>La balise "secret" (appelée "spoiler" sur certains sites) a ceci de spécial qu'elle masque son contenu par défaut et ne le rend visible qu'au clic de l'utilisateur.</p>
+<p>La balise "secret" (appelée "spoiler" sur certains sites) a ceci de spécial qu&rsquo;elle masque son contenu par défaut et ne le rend visible qu&rsquo;au clic de l&rsquo;utilisateur.</p>
 <h3>Citations</h3>
-<p>Les citations permettent de séparer votre propos de celui que vous rapportez. D'ailleurs, si l'on en croit ce vieux proverbe nous venant d'une petite planète quelque part aux confins de Bételgeuse, il ne faut pas s'en priver :</p>
+<p>Les citations permettent de séparer votre propos de celui que vous rapportez. D&rsquo;ailleurs, si l&rsquo;on en croit ce vieux proverbe nous venant d&rsquo;une petite planète quelque part aux confins de Bételgeuse, il ne faut pas s&rsquo;en priver&#x202F;:</p>
 <figure><blockquote>
-<p>Les citations, c'est bien.
+<p>Les citations, c&rsquo;est bien.
 </p>
 </blockquote>
-<figcaption><p>Petite planète quelque part aux confins de Bételgeuse</p></figcaption></figure><p>On utilise pour cela un chevron devant chaque début de ligne, avec optionnellement votre source, écrite de la même façon que les légendes (avec le mot-clé <code>Source</code>) :</p>
+<figcaption><p>Petite planète quelque part aux confins de Bételgeuse</p></figcaption></figure><p>On utilise pour cela un chevron devant chaque début de ligne, avec optionnellement votre source, écrite de la même façon que les légendes (avec le mot-clé <code>Source</code>)&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>&gt; Ceci est une citation

--- a/tests/zds/rediger_sur_zds_part8.html
+++ b/tests/zds/rediger_sur_zds_part8.html
@@ -38,8 +38,7 @@
 <h3>Citations</h3>
 <p>Les citations permettent de séparer votre propos de celui que vous rapportez. D&rsquo;ailleurs, si l&rsquo;on en croit ce vieux proverbe nous venant d&rsquo;une petite planète quelque part aux confins de Bételgeuse, il ne faut pas s&rsquo;en priver&#x202F;:</p>
 <figure><blockquote>
-<p>Les citations, c&rsquo;est bien.
-</p>
+<p>Les citations, c&rsquo;est bien.</p>
 </blockquote>
 <figcaption><p>Petite planète quelque part aux confins de Bételgeuse</p></figcaption></figure><p>On utilise pour cela un chevron devant chaque début de ligne, avec optionnellement votre source, écrite de la même façon que les légendes (avec le mot-clé <code>Source</code>)&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1

--- a/tests/zds/rediger_sur_zds_part9.html
+++ b/tests/zds/rediger_sur_zds_part9.html
@@ -1,5 +1,5 @@
 <h3>Abréviations</h3>
-<p>Il est souvent utile de préciser la signification d'une abréviation (notamment d'un acronyme ou d'un sigle), sans toutefois la faire figurer dans le corps du texte. En utilisant la syntaxe suivante, la signification apparaîtra au passage de la souris sur l'abréviation :</p>
+<p>Il est souvent utile de préciser la signification d&rsquo;une abréviation (notamment d&rsquo;un acronyme ou d&rsquo;un sigle), sans toutefois la faire figurer dans le corps du texte. En utilisant la syntaxe suivante, la signification apparaîtra au passage de la souris sur l&rsquo;abréviation&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3</pre></div></td><td class="code"><div class="codehilite"><pre><span></span>Bienvenue sur ZdS !
@@ -8,9 +8,9 @@
 </pre></div>
 </td></tr></table>
 
-<p>Bienvenue, donc, sur <abbr title="Zeste de Savoir">ZdS</abbr> !</p>
+<p>Bienvenue, donc, sur <abbr title="Zeste de Savoir">ZdS</abbr>&#x202F;!</p>
 <h3>Notes de bas de page</h3>
-<p>Toujours dans l'idée d'enrichir votre texte<sup id="fnref-enrich"><a class="footnote-ref" href="#fn-enrich">1</a></sup>, vous pouvez utiliser des notes de base de page :</p>
+<p>Toujours dans l&rsquo;idée d&rsquo;enrichir votre texte<sup id="fnref-enrich"><a class="footnote-ref" href="#fn-enrich">1</a></sup>, vous pouvez utiliser des notes de base de page&#x202F;:</p>
 <table class="codehilitetable"><tr><td class="linenos"><div class="linenodiv"><pre>1
 2
 3
@@ -23,12 +23,12 @@
 </pre></div>
 </td></tr></table>
 
-<p>Les notes sont alors numérotées automatiquement. Vous n'avez à vous soucier que du nom que vous donner à votre note.</p>
+<p>Les notes sont alors numérotées automatiquement. Vous n&rsquo;avez à vous soucier que du nom que vous donner à votre note.</p>
 <div class="footnote">
 <hr>
 <ol>
 <li id="fn-enrich">
-<p>Sans pour autant l'alourdir.&#160;<a class="footnote-backref" href="#fnref-enrich" title="Retourner au texte de la note 1">&#8617;</a></p>
+<p>Sans pour autant l&rsquo;alourdir.&#160;<a class="footnote-backref" href="#fnref-enrich" title="Retourner au texte de la note 1">&#8617;</a></p>
 </li>
 </ol>
 </div>


### PR DESCRIPTION
Il s’agit d’une reprise de la PR https://github.com/zestedesavoir/Python-ZMarkdown/pull/76 concernant le nouveau module de typographie française. Par rapport à la PR précédente, voici les changements.
- J’ai intégré la suggestion de @davbaumgartner d’utiliser `&#x202F;` plutôt que `&nbsp;` pour les espaces insécables fines.
- J’ai corrigé un bogue qui faisait que les espaces insécables n’étaient pas insérées devant `:` et `;` si ceux-ci terminaient la ligne.
- J’ai mis à jour les fichiers de tests pour que les résultats prennent en compte les modifs faites par ce module. En revanche, je n’arrive pas à utiliser le système de test actuellement en usage, donc je n’ai pas pu rédiger de test spécifique à cette extension.
- ~~**Il est apparu un bogue que je ne parviens pas à corriger** : le smiley `:'(` n’est plus reconnu. En effet, l’apostrophe devient une apostrophe typographique, et lorsque je modifie l’expression régulière pour qu’elle ne prenne pas en compte la suite `:'(`, alors, c’est l’extension qui gère les _smileys_ qui ne le détecte plus. Je suis un peu coincé, là…~~ Apparemment, ça venait de moi, TRAVIS n’a pas le problème.
